### PR TITLE
Wrap DEFINE-CONSTANT forms in EVAL-ALWAYS

### DIFF
--- a/graphics/tools/image/src/color/luv.lisp
+++ b/graphics/tools/image/src/color/luv.lisp
@@ -1,7 +1,8 @@
 (in-package #:mfiano.graphics.tools.image.color)
 
-(u:define-constant +cie-e+ #.(float 216/24389 1d0))
-(u:define-constant +cie-k+ #.(float 24389/27 1d0))
+(u:eval-always
+  (u:define-constant +cie-e+ #.(float 216/24389 1d0))
+  (u:define-constant +cie-k+ #.(float 24389/27 1d0)))
 
 (defun luv->xyz (in out)
   (declare (optimize speed))


### PR DESCRIPTION
This fixes an error in CCL where a read-time-eval of a constant defined in the
same file will fail, because the read-time-eval happens before the constant is
defined by the compiler