### PR TITLE
Avoid complex numbers without clamping

### DIFF
--- a/graphics/image/src/color/rgb.lisp
+++ b/graphics/image/src/color/rgb.lisp
@@ -183,12 +183,12 @@
 
 (defmethod linearize-rgb-channel (value (gamma double-float))
   (if (minusp value)
-      0d0
+      (- (expt (- value) gamma))
       (expt value gamma)))
 
 (defmethod delinearize-rgb-channel (value (gamma double-float))
   (if (minusp value)
-      0d0
+      (- (expt (- value) (/ gamma)))
       (expt value (/ gamma))))
 
 (defmethod linearize-rgb-channel (value (gamma (eql 'L*)))


### PR DESCRIPTION
Pretty much exactly what it says on the tin, we do exponentiation on positive
numbers, then negate them